### PR TITLE
[Bugfix] Refactor FlowResource to update JSON input_content handling

### DIFF
--- a/fondat/aws/bedrock/resources/flows.py
+++ b/fondat/aws/bedrock/resources/flows.py
@@ -223,7 +223,7 @@ class FlowResource:
         Args:
             input_content: The input content to process. Can be:
                 - A string for text input
-                - A dictionary for JSON input (will be converted to string)
+                - A dictionary for JSON input (will be sent as object)
             flowAliasIdentifier: The unique identifier of the flow alias
             nodeName: Optional name of the node to start from. Defaults to "input"
             nodeInputName: Optional name of the node input
@@ -235,14 +235,11 @@ class FlowResource:
         Returns:
             FlowInvocation: Information about the flow invocation
         """
-        str_content = (
-            input_content if isinstance(input_content, str) else json.dumps(input_content)
-        )
 
         params = {
             "flowIdentifier": self._flow_id,
             "flowAliasIdentifier": flowAliasIdentifier,
-            "inputs": [{"nodeName": nodeName, "content": {"document": str_content}}],
+            "inputs": [{"nodeName": nodeName, "content": {"document": input_content}}],
             "enableTrace": enableTrace,
         }
         if nodeInputName is not None:


### PR DESCRIPTION
# Issue
https://app.clickup.com/t/36721826/ENG-4244

## What’s Changed
- **Input handling for JSON flows**: the `invoke` method in `fondat/aws/bedrock/resources/flows.py` no longer stringifies JSON payloads by default.
- Now, when you load the JSON file (e.g., using `json.load(f)`), the resulting Python object will be sent as a native JSON object to the flow.

<summary>Key diff</summary>

```diff
@@ def invoke(...):
-    str_content = (
-        input_content if isinstance(input_content, str)
-        else json.dumps(input_content)
-    )
-    params = {
-        ...
-        "inputs": [
-            { "nodeName": nodeName, "content": { "document": str_content } }
-        ],
-        ...
-    }
+    params = {
+        ...
+        "inputs": [
+            { "nodeName": nodeName, "content": { "document": input_content } }
+        ],
+        ...
+    }
```

## How to Verify
1. All existing unit and integration tests must pass.
2. **Manual test**: invoke any Bedrock flow with a JSON payload, for example:

```python
response = await flows["<flow-id>"].invoke(
    input_content=my_json_dict,
    flowAliasIdentifier="<flow-alias>",
    nodeName="FlowInputNode",
    nodeOutputName="document",
)
assert response is not None  # and you receive a valid flow response
```

—you should get a successful response without having wrapped `my_json_dict` in a string.
