### PR TITLE
Enhance FlowResource to support streaming mode

### DIFF
--- a/fondat/aws/bedrock/decorators.py
+++ b/fondat/aws/bedrock/decorators.py
@@ -12,6 +12,7 @@ T = TypeVar("T")
 def operation(
     method: str,
     policies: Policy | Callable[[Any], Policy] | None = None,
+    type: str | None = None,
 ) -> Callable[[T], T]:
     """
     Shorthand decorator for Fondat operations with method and policies.
@@ -19,6 +20,7 @@ def operation(
     Args:
         method: The HTTP method for the operation
         policies: Optional security policies or callable that returns policies
+        type: Optional operation type (e.g., "mutation")
 
     Returns:
         A decorator function that adds the operation metadata
@@ -27,7 +29,10 @@ def operation(
     def decorator(func: T) -> T:
         def wrapper(self: Any, *args: Any, **kwargs: Any) -> T:
             actual_policies = policies(self) if callable(policies) else policies
-            return _operation(method=method, policies=actual_policies)(func)(
+            operation_kwargs = {"method": method, "policies": actual_policies}
+            if type is not None:
+                operation_kwargs["type"] = type
+            return _operation(**operation_kwargs)(func)(
                 self, *args, **kwargs
             )
 

--- a/fondat/aws/bedrock/resources/flows.py
+++ b/fondat/aws/bedrock/resources/flows.py
@@ -1,8 +1,11 @@
 """Resource for managing agent flows."""
 
-import json
+import sys
+from contextlib import AsyncExitStack
 from collections.abc import Iterable
+from typing import Any, List
 
+from fondat.aws.bedrock.resources.streams import FlowStream
 from fondat.aws.bedrock.utils import convert_dict_keys_to_snake_case
 from fondat.aws.client import Config, wrap_client_error
 from fondat.aws.bedrock.domain import Flow, FlowInvocation, FlowSummary
@@ -142,6 +145,52 @@ class FlowResource:
         self.config_runtime = config_runtime
         self.policies = policies
 
+    def _build_params(
+        self,
+        input_content: str | dict,
+        flowAliasIdentifier: str,
+        nodeName: str,
+        nodeInputName: str | None,
+        nodeOutputName: str | None,
+        enableTrace: bool,
+        executionId: str | None,
+        modelPerformanceConfiguration: dict | None,
+    ) -> dict[str, Any]:
+        """
+        Build parameters for invoking the flow.
+        """
+        params: dict[str, Any] = {
+            "flowIdentifier": self._flow_id,
+            "flowAliasIdentifier": flowAliasIdentifier,
+            "inputs": [{"content": {"document": input_content}, "nodeName": nodeName}],
+            "enableTrace": enableTrace,
+        }
+        if nodeInputName is not None:
+            params["inputs"][0]["nodeInputName"] = nodeInputName
+        if nodeOutputName is not None:
+            params["inputs"][0]["nodeOutputName"] = nodeOutputName
+        if executionId is not None:
+            params["executionId"] = executionId
+        if modelPerformanceConfiguration is not None:
+            params["modelPerformanceConfiguration"] = {
+                "performanceConfig": modelPerformanceConfiguration
+            }
+        return params
+
+    async def _collect_events(self, stream_obj: Any) -> List[dict]:
+        """
+        Consume the Bedrock responseStream whether it's sync (botocore) or async (aiobotocore),
+        and return a list of events.
+        """
+        events: list[dict] = []
+        if hasattr(stream_obj, "__aiter__"):
+            async for e in stream_obj:  # type: ignore[attr-defined]
+                events.append(e)
+        else:
+            for e in stream_obj:  # type: ignore[operator]
+                events.append(e)
+        return events
+
     @operation(method="get", policies=lambda self: self.policies)
     async def get(self) -> Flow:
         """
@@ -163,6 +212,109 @@ class FlowResource:
                 data["_factory"] = lambda: self
                 data = convert_dict_keys_to_snake_case(data)
                 return Flow(**data)
+
+    @operation(method="post", type="mutation", policies=lambda self: self.policies)
+    async def invoke_buffered(
+        self,
+        input_content: str | dict,
+        flowAliasIdentifier: str,
+        *,
+        nodeName: str = "FlowInputNode",
+        nodeInputName: str | None = None,
+        nodeOutputName: str | None = None,
+        enableTrace: bool = False,
+        executionId: str | None = None,
+        modelPerformanceConfiguration: dict | None = None,
+    ) -> FlowInvocation:
+        """
+        Invoke the flow and return a FlowInvocation object.
+
+        Args:
+            input_content: The input content to process. Can be:
+                - A string for text input
+                - A dictionary for JSON input (will be sent as object)
+            flowAliasIdentifier: The unique identifier of the flow alias
+            nodeName: Optional name of the node to start from. Defaults to "input"
+            nodeInputName: Optional name of the node input
+            nodeOutputName: Optional name of the node output
+            enableTrace: Whether to enable trace information
+            executionId: Optional execution identifier
+            modelPerformanceConfiguration: Optional model performance configuration
+
+        Returns:
+            FlowInvocation: Information about the flow invocation
+        """
+        params = self._build_params(
+            input_content,
+            flowAliasIdentifier,
+            nodeName,
+            nodeInputName,
+            nodeOutputName,
+            enableTrace,
+            executionId,
+            modelPerformanceConfiguration,
+        )
+
+        async with runtime_client(self.config_runtime) as client:
+            with wrap_client_error():
+                response = await client.invoke_flow(**params)
+
+            events = await self._collect_events(response.get("responseStream"))
+
+        data = {k: v for k, v in response.items() if k != "ResponseMetadata"}
+        data = convert_dict_keys_to_snake_case(data)
+        data["response_stream"] = events
+        return FlowInvocation(**data)
+
+    @operation(method="post", type="mutation", policies=lambda self: self.policies)
+    async def invoke_streaming(
+        self,
+        input_content: str | dict,
+        flowAliasIdentifier: str,
+        *,
+        nodeName: str = "FlowInputNode",
+        nodeInputName: str | None = None,
+        nodeOutputName: str | None = None,
+        enableTrace: bool = False,
+        executionId: str | None = None,
+        modelPerformanceConfiguration: dict | None = None,
+    ) -> FlowStream:
+        """
+        Invoke the flow and return a live async iterator of events.
+
+        Args:
+            input_content: The input content to process. Can be:
+                - A string for text input
+                - A dictionary for JSON input (will be sent as object)
+            flowAliasIdentifier: The unique identifier of the flow alias
+            nodeName: Optional name of the node to start from. Defaults to "input"
+            nodeInputName: Optional name of the node input
+            nodeOutputName: Optional name of the node output
+            enableTrace: Whether to enable trace information
+            executionId: Optional execution identifier
+            modelPerformanceConfiguration: Optional model performance configuration
+
+        Returns:
+            FlowStream: An async iterator of events
+        """
+        params = self._build_params(
+            input_content,
+            flowAliasIdentifier,
+            nodeName,
+            nodeInputName,
+            nodeOutputName,
+            enableTrace,
+            executionId,
+            modelPerformanceConfiguration,
+        )
+
+        stack = AsyncExitStack()
+        client = await stack.enter_async_context(runtime_client(self.config_runtime))
+        with wrap_client_error():
+            response = await client.invoke_flow(**params)
+
+        # FlowStream will call stack.aclose() when iteration finishes
+        return FlowStream(response, stack)
 
     @property
     def versions(self) -> GenericVersionResource:
@@ -203,58 +355,3 @@ class FlowResource:
             config=self.config_agent,
             policies=self.policies,
         )
-
-    @operation(method="post", policies=lambda self: self.policies)
-    async def invoke(
-        self,
-        input_content: str | dict,
-        flowAliasIdentifier: str,
-        *,
-        nodeName: str = "FlowInputNode",
-        nodeInputName: str | None = None,
-        nodeOutputName: str | None = None,
-        enableTrace: bool = False,
-        executionId: str | None = None,
-        modelPerformanceConfiguration: dict | None = None,
-    ) -> FlowInvocation:
-        """
-        Invoke the flow with the given input.
-
-        Args:
-            input_content: The input content to process. Can be:
-                - A string for text input
-                - A dictionary for JSON input (will be sent as object)
-            flowAliasIdentifier: The unique identifier of the flow alias
-            nodeName: Optional name of the node to start from. Defaults to "input"
-            nodeInputName: Optional name of the node input
-            nodeOutputName: Optional name of the node output
-            enableTrace: Whether to enable trace information
-            executionId: Optional execution identifier
-            modelPerformanceConfiguration: Optional model performance configuration
-
-        Returns:
-            FlowInvocation: Information about the flow invocation
-        """
-
-        params = {
-            "flowIdentifier": self._flow_id,
-            "flowAliasIdentifier": flowAliasIdentifier,
-            "inputs": [{"content": {"document": input_content}, "nodeName": nodeName}],
-            "enableTrace": enableTrace,
-        }
-        if nodeInputName is not None:
-            params["inputs"][0]["nodeInputName"] = nodeInputName
-        if nodeOutputName is not None:
-            params["inputs"][0]["nodeOutputName"] = nodeOutputName
-        if executionId is not None:
-            params["executionId"] = executionId
-        if modelPerformanceConfiguration is not None:
-            params["modelPerformanceConfiguration"] = {
-                "performanceConfig": modelPerformanceConfiguration
-            }
-        async with runtime_client(self.config_runtime) as client:
-            with wrap_client_error():
-                response = await client.invoke_flow(**params)
-                flow_data = {k: v for k, v in response.items() if k != "ResponseMetadata"}
-                flow_data = convert_dict_keys_to_snake_case(flow_data)
-                return FlowInvocation(**flow_data)

--- a/fondat/aws/bedrock/resources/generic_resources.py
+++ b/fondat/aws/bedrock/resources/generic_resources.py
@@ -271,17 +271,14 @@ class VersionResource(Generic[VT]):
     def _map_response_fields(self, response_data: dict[str, Any]) -> dict[str, Any]:
         """Map response fields according to resource type."""
         mapping = self._get_field_mappings()
-        print(f"\nField mappings: {mapping}")
         # map only present fields (dest_field ← response_data[src_field])
         mapped = {
             dest: response_data[src] if src in response_data else None
             for dest, src in mapping.items()
         }
-        print(f"\nMapped fields: {mapped}")
 
         # validate that *destination* keys are all present
         required = self._get_required_fields()
-        print(f"\nRequired fields: {required}")
         missing = set(required) - mapped.keys()
         if missing:
             raise ValueError(f"Missing required fields for {self.id_field}: {sorted(missing)}")
@@ -301,11 +298,8 @@ class VersionResource(Generic[VT]):
         async with agent_client(self.config) as client:
             response = await getattr(client, self.get_method)(**params)
             data = {k: v for k, v in response.items() if k != "ResponseMetadata"}
-            print(f"\nAPI Response data: {data}")
             data = convert_dict_keys_to_snake_case(data)
-            print(f"\nAfter snake_case conversion: {data}")
             mapped = self._map_response_fields(data)
-            print(f"\nAfter mapping: {mapped}")
             return self._dto_type(**mapped)
 
 
@@ -410,9 +404,7 @@ class GenericAliasResource:
 
         async with agent_client(self.config) as client:
             resp = await getattr(client, self.list_method)(**params)
-            print(f"\nAPI Response: {resp}")
             field_mapping = self._get_field_mapping()
-            print(f"\nField mapping: {field_mapping}")
             return paginate(
                 resp=resp,
                 items_key=self.items_key,

--- a/fondat/aws/bedrock/resources/streams.py
+++ b/fondat/aws/bedrock/resources/streams.py
@@ -1,0 +1,61 @@
+from collections.abc import AsyncIterator
+from types import TracebackType
+from typing import Any, Optional, Type
+
+class FlowStream(AsyncIterator[dict]):
+    """
+    Async iterator that keeps the underlying runtime_client session alive
+    until the caller finishes iterating, then closes it cleanly.
+    """
+
+    def __init__(self, response: dict, client_cm):
+        # response is the original dict returned by invoke_flow
+        self._response = response
+        self._client_cm = client_cm
+        self._closed = False
+        stream = response.get("responseStream")
+        if hasattr(stream, "__aiter__"):
+            # Async iterator (aiobotocore)
+            self._stream_async = True
+            self._async_iter = stream.__aiter__()
+        else:
+            # Sync iterator (botocore EventStream)
+            self._stream_async = False
+            self._sync_iter = iter(stream)
+
+    # ------------- async iterator protocol -------------
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            if self._stream_async:
+                # Async iteration
+                return await self._async_iter.__anext__()
+            else:
+                # Sync iteration
+                return next(self._sync_iter)
+        except (StopAsyncIteration, StopIteration):
+            # auto-close when stream ends
+            await self.close()
+            raise StopAsyncIteration
+
+    # ------------- async context-manager helpers -------------
+    async def __aenter__(self):
+        # let users do:  async with stream as s:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ):
+        await self.close()
+
+    # ------------- public helper -------------
+    async def close(self):
+        """Close the underlying aiohttp session if not already closed."""
+        if not self._closed:
+            await self._client_cm.__aexit__(None, None, None)
+            self._closed = True


### PR DESCRIPTION
# ENG-4244 – Streaming support for Flow invocations

**Issue:**  
https://app.clickup.com/t/36721826/ENG-4244

---

## What’s Changed

### Summary

Streaming support is now implemented with two explicit operations instead of a single toggle flag:

- `invoke_buffered(...) -> FlowInvocation` – returns all events collected.
- `invoke_streaming(...) -> FlowStream` – returns an async iterator for real‑time consumption.

This keeps lifecycles clear, avoids private `__aenter__` / `__aexit__` calls, and fits Fondat’s allowance for multiple POST *mutations*.

### Changes Made

1. **Split API surface**
   - Replaced the old `invoke(..., stream: bool)` with:
     - `invoke_buffered(...) -> FlowInvocation`
     - `invoke_streaming(...) -> FlowStream`
   - Both decorated with `@operation(method="post", type="mutation")`.

2. **Shared helpers**
   - `_build_params(...)` to construct the Bedrock payload.
   - `_collect_events(stream_obj)` to consume either sync (botocore) or async (aiobotocore) streams uniformly.

3. **Streaming resource management**
   - `invoke_streaming` uses `AsyncExitStack` to keep the runtime client open until iteration completes.  
     `FlowStream` closes the stack when done.

4. **Buffered path simplification**
   - Uses a normal `async with runtime_client(...)` block. No private context-manager methods needed.
   - Events are collected via `_collect_events`.

5. **Input payload order & defaults**
   - Still sending `{"content": ..., "nodeName": ...}` to satisfy Bedrock’s parsing quirks.
   - Default `nodeName` remains `"FlowInputNode"`.

6. **New module**
   - `fondat/aws/bedrock/resources/streams.py` with the `FlowStream` iterator/context manager.

7. **Operation decorator enhancement**
   - Added optional `type` argument to our shorthand `operation` decorator to pass through Fondat’s `type="mutation"`.

8. **Tests added/updated**
   - **Unit:** `tests/bedrock/unit/test_flows.py::test_invoke_flow_streaming`
   - **Integration:**
     - `tests/bedrock/integration/test_integration_sessions_and_invoke.py::test_invoke_flow` (buffered)
     - `tests/bedrock/integration/test_integration_sessions_and_invoke.py::test_invoke_flow_streaming` (streaming)

9. **Cleanup**
   - Removed stray `print` debug statements from resource modules.

---

## How to Use

### Buffered

```python
invocation = await flow_resource.invoke_buffered(
    input_content={"context": "crc", "prompt": "analysis", "input": json_input},
    flowAliasIdentifier="<alias>",
    nodeOutputName="document",
    nodeName="FlowInputNode",
)

events = invocation.response_stream  # list[dict]
```

### Streaming

```python
stream = await flow_resource.invoke_streaming(
    input_content={"context": "crc", "prompt": "analysis", "input": json_input},
    flowAliasIdentifier="<alias>",
    nodeOutputName="document",
    nodeName="FlowInputNode",
)

result = {}
async with stream as s:
    async for event in s:
        result.update(event)
```

---

## How to Verify

1. Configure AWS credentials & env vars.  
2. Run the full suite:

```bash
pytest tests/bedrock/ -v
```

Both unit and integration streaming tests should pass.
